### PR TITLE
The 'license' field should not contain the word "license".

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ test:
 
 about:
   home: https://nipy.org/dipy
-  license:  3-clause BSD license
+  license:  3-clause BSD
   license_file: LICENSE
   summary: Diffusion MR Imaging in Python
 


### PR DESCRIPTION
See linter comment in #7.