### PR TITLE
setup compiler for appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@
 # Post-conda-smithy customization: build on this OS until we can figure out
 # how to workaround a compiler bug introduced in Update 3.
 os:
-  - Visual Studio 2015 Update 2
+    - Visual Studio 2015 Update 2
 
 environment:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,12 @@
 # file, make changes to conda-forge.yml and/or recipe/meta.yaml, and run
 # "conda smithy rerender".
 
+
+# Post-conda-smithy customization: build on this OS until we can figure out
+# how to workaround a compiler bug introduced in Update 3.
+os:
+  - Visual Studio 2015 Update 2
+
 environment:
 
   BINSTAR_TOKEN:
@@ -27,11 +33,11 @@ environment:
 
     - TARGET_ARCH: x86
       CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda36
+      CONDA_INSTALL_LOCN: C:\\Miniconda35
 
     - TARGET_ARCH: x64
       CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
 
 # We always use a 64-bit machine, but can build x86 distributions

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,12 +2,6 @@
 # file, make changes to conda-forge.yml and/or recipe/meta.yaml, and run
 # "conda smithy rerender".
 
-
-# Post-conda-smithy customization: build on this OS until we can figure out
-# how to workaround a compiler bug introduced in Update 3.
-os:
-    - Visual Studio 2015 Update 2
-
 environment:
 
   BINSTAR_TOKEN:
@@ -33,11 +27,11 @@ environment:
 
     - TARGET_ARCH: x86
       CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda35
+      CONDA_INSTALL_LOCN: C:\\Miniconda36
 
     - TARGET_ARCH: x64
       CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
+      CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
 
 
 # We always use a 64-bit machine, but can build x86 distributions

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,12 @@
 # file, make changes to conda-forge.yml and/or recipe/meta.yaml, and run
 # "conda smithy rerender".
 
+
+# Post-conda-smithy customization: build on this OS until we can figure out
+# how to workaround a compiler bug introduced in Update 3.
+os:
+    - Visual Studio 2015 Update 2
+
 environment:
 
   BINSTAR_TOKEN:
@@ -27,11 +33,11 @@ environment:
 
     - TARGET_ARCH: x86
       CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda36
+      CONDA_INSTALL_LOCN: C:\\Miniconda35
 
     - TARGET_ARCH: x64
       CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
 
 # We always use a 64-bit machine, but can build x86 distributions


### PR DESCRIPTION
Builds are failing on windows because of visual studio update 3. (reminder #12)

The goal of this PR is to do this small update for Windows users
